### PR TITLE
🐛 Fixed manifest for our caapc controller to remove the variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,14 +71,17 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Production image
 FROM ${deployment_base_image}:${deployment_base_image_tag}
 
+# Build architecture - redeclare for this stage
+ARG ARCH
+
 # Set shell with pipefail option for better error handling
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
 RUN apk add --no-cache ca-certificates curl nodejs npm \
     && npm install -g cdk8s-cli@2.200.109 \
-    && curl -fsSL -o go1.24.4.linux-amd64.tar.gz https://go.dev/dl/go1.24.4.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz \
-    && rm go1.24.4.linux-amd64.tar.gz \
+    && curl -fsSL -o go1.24.4.linux-${ARCH}.tar.gz https://go.dev/dl/go1.24.4.linux-${ARCH}.tar.gz \
+    && tar -C /usr/local -xzf go1.24.4.linux-${ARCH}.tar.gz \
+    && rm go1.24.4.linux-${ARCH}.tar.gz \
     && rm -rf /tmp/*
 
 # Set Go environment variables

--- a/Makefile
+++ b/Makefile
@@ -220,9 +220,9 @@ CAPI_KIND_CLUSTER_NAME ?= capi-test
 # It is set by Prow GIT_TAG, a git-based tag of the form vYYYYMMDD-hash, e.g., v20210120-v0.3.10-308-gc61521971
 
 #TAG ?= dev
-TAG ?= v1.0.0-alpha.6
+TAG ?= v1.0.0-alpha.7
 ARCH ?= $(shell go env GOARCH)
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH = amd64 arm64 #ppc64le s390 arm
 
 # Allow overriding manifest generation destination directory
 MANIFEST_ROOT ?= config
@@ -407,7 +407,7 @@ docker-build-%:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for core controller manager
-	DOCKER_BUILDKIT=1 docker build $(BUILD_CONTAINER_ADDITIONAL_ARGS) --build-arg builder_image=$(GO_CONTAINER_IMAGE) --build-arg deployment_base_image=$(DEPLOYMENT_BASE_IMAGE) --build-arg deployment_base_image_tag=$(DEPLOYMENT_BASE_IMAGE_TAG) --build-arg goproxy=$(GOPROXY) --build-arg goprivate=$(GOPRIVATE) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build $(BUILD_CONTAINER_ADDITIONAL_ARGS) --platform=linux/$(ARCH) --build-arg builder_image=$(GO_CONTAINER_IMAGE) --build-arg deployment_base_image=$(DEPLOYMENT_BASE_IMAGE) --build-arg deployment_base_image_tag=$(DEPLOYMENT_BASE_IMAGE_TAG) --build-arg goproxy=$(GOPROXY) --build-arg goprivate=$(GOPRIVATE) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"
 

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller:v1.0.0-alpha.6
+      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller:v1.0.0-alpha.7
         name: manager

--- a/config/default/manager_image_patch.yaml-e
+++ b/config/default/manager_image_patch.yaml-e
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller:v1.0.0-alpha.6
+      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller:v1.0.0-alpha.7
         name: manager

--- a/config/default/manager_pull_policy.yaml-e
+++ b/config/default/manager_pull_policy.yaml-e
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the variant from the docker manifest, to allow the installation of the caapc controller on amd64 based archs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #17 
