### PR TITLE
🌱 chore: bumping go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eitco/cluster-api-addon-provider-cdk8s
 
-go 1.24.4
+go 1.25.0
 
 require (
 	github.com/go-git/go-git/v5 v5.16.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates Go Version to 1.25.0

**Which issue(s) this PR fixes**:
Fixes #28 
