### PR TITLE
✨ Fixing container build for other archs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,9 +220,10 @@ CAPI_KIND_CLUSTER_NAME ?= capi-test
 # It is set by Prow GIT_TAG, a git-based tag of the form vYYYYMMDD-hash, e.g., v20210120-v0.3.10-308-gc61521971
 
 #TAG ?= dev
+# Next release v1.0.0-alpha.11
 TAG ?= v1.0.0-alpha.10
 ARCH ?= $(shell go env GOARCH)
-ALL_ARCH = amd64 arm64 #ppc64le s390 arm
+ALL_ARCH = amd64 arm64 ppc64le
 
 # Allow overriding manifest generation destination directory
 MANIFEST_ROOT ?= config

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Examples of `Cdk8sAppProxy` usage can be found in the `/examples` directory in t
 -   [`examples/cdk8sappproxy_sample-go.yaml`](./examples/cdk8sappproxy_sample-go.yaml): This example demonstrates how to deploy a sample cdk8s application from a public Git repository to clusters matching a specific label selector. It shows the usage of the `gitRepository` field.
 -   [`examples/cdk8sappproxy_sample-typescript.yaml`](./examples/cdk8sappproxy_sample-typescript.yaml): This directory contains a sample cdk8s application written in Typescript, which also generates a kustomization file.
 
+### Supported Platforms:
+
+`amd64 arm64 ppc64le`
+
+`s390` and `arm` is currently not supported.
+
 ### Code of conduct
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller-arm64:v1.0.0-alpha.10
+      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller:v1.0.0-alpha.10
         name: manager

--- a/config/default/manager_image_patch.yaml-e
+++ b/config/default/manager_image_patch.yaml-e
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller-amd64:v1.0.0-alpha.10
+      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller-ppc64le:v1.0.0-alpha.10
         name: manager

--- a/hack/update-ssh-known-hosts.sh
+++ b/hack/update-ssh-known-hosts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes container builds, and moves the known_host fetch to a separate build stage in the Dockerfile.

**Which issue(s) this PR fixes**:
Fixes #19 
