### PR TITLE
🌱 Switched version management to Makefile

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller:v1.0.0-alpha.12-8
+      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller:dev
         name: manager

--- a/config/default/manager_image_patch.yaml-e
+++ b/config/default/manager_image_patch.yaml-e
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller:v1.0.0-alpha.12-8
+      - image: ghcr.io/eitco/cluster-api-addon-provider-cdk8s/cluster-api-cdk8s-controller-ppc64le:dev
         name: manager

--- a/config/default/manager_pull_policy.yaml
+++ b/config/default/manager_pull_policy.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always


### PR DESCRIPTION
**What this PR does / why we need it**:
Version management is now moved to the makefile. We just pass the version from there on build-time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #77 
